### PR TITLE
Protect memcached injection

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,5 +1,7 @@
 package memgo
 
+import "net/url"
+
 // https://github.com/memcached/memcached/blob/master/doc/protocol.txt
 
 const (
@@ -13,6 +15,15 @@ type Client struct {
 
 func NewClient(servers []string, config Config) Client {
 	return Client{Servers: NewServers(servers, config.connectTimeout()), Config: config}
+}
+
+type Key struct {
+	body string
+}
+
+func newKey(value string) Key {
+	escaped := url.QueryEscape(value)
+	return Key{body: escaped}
 }
 
 var DefaultClient = NewClient([]string{"localhost:11211"}, Config{})

--- a/client.go
+++ b/client.go
@@ -1,6 +1,10 @@
 package memgo
 
-import "net/url"
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"net/url"
+)
 
 // https://github.com/memcached/memcached/blob/master/doc/protocol.txt
 
@@ -21,8 +25,17 @@ type Key struct {
 	body string
 }
 
+func hashMD5(s string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(s))
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
 func newKey(value string) Key {
 	escaped := url.QueryEscape(value)
+	if len(escaped) > 250 {
+		escaped = hashMD5(escaped)
+	}
 	return Key{body: escaped}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -81,6 +81,24 @@ func TestMemcachedInjection(t *testing.T) {
 			t.Errorf("actual %v, expected %v", err2, "nil")
 		}
 	})
+
+	t.Run("interprets data to store as command", func(t *testing.T) {
+		flushAll(t)
+
+		actual, err := Set(Item{Key:generateRandomString(251), Value: "set injected 0 3600 5\r\n12345"})
+		if actual != nil {
+			t.Errorf("actual %v, expected %v", actual, "nil")
+		}
+		_, isErrClient := err.(*ErrClient)
+		if !isErrClient {
+			t.Errorf("actual %v, expected %v", err, "ErrClient")
+		}
+
+		actual2, _ := Get("injected")
+		if actual2.Value == "12345" {
+			t.Errorf("it has MemcachedInjection risk!. actual %v, expected %v", actual2, "Response{}")
+		}
+	})
 }
 
 func TestSetAndGet(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -61,24 +61,26 @@ func TestSet(t *testing.T) {
 }
 
 func TestMemcachedInjection(t *testing.T) {
-	flushAll(t)
+	t.Run("command injection", func(t *testing.T) {
+		flushAll(t)
 
-	key := "foo\r\nset bar 0 0 4\r\ntest"
-	actual, err := Get(key)
-	if actual != nil {
-		t.Errorf("actual %v, expected %v", actual, "nil")
-	}
-	if err != nil {
-		t.Errorf("actual %v, expected %v", err, "nil")
-	}
+		key := "foo\r\nset bar 0 0 4\r\ntest"
+		actual, err := Get(key)
+		if actual != nil {
+			t.Errorf("actual %v, expected %v", actual, "nil")
+		}
+		if err != nil {
+			t.Errorf("actual %v, expected %v", err, "nil")
+		}
 
-	actual2, err2 := Get("bar")
-	if actual2 == (&Response{}) {
-		t.Errorf("it has MemcachedInjection risk!. actual %v, expected %v", actual2, "Response{}")
-	}
-	if err2 != nil {
-		t.Errorf("actual %v, expected %v", err2, "nil")
-	}
+		actual2, err2 := Get("bar")
+		if actual2 == (&Response{}) {
+			t.Errorf("it has MemcachedInjection risk!. actual %v, expected %v", actual2, "Response{}")
+		}
+		if err2 != nil {
+			t.Errorf("actual %v, expected %v", err2, "nil")
+		}
+	})
 }
 
 func TestSetAndGet(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -48,6 +48,14 @@ func TestSet(t *testing.T) {
 		if res.CasId != 0 {
 			t.Errorf("actual %v, expected %v", res.CasId, 0)
 		}
+
+		res, err = Get(key)
+		if res.Value != "123" {
+			t.Errorf("actual %v, expected %v", res.Value, "123")
+		}
+		if err != nil {
+			t.Errorf("actual %v, expected %v", err, "nil")
+		}
 	})
 
 	t.Run("when the Key size is 251", func(t *testing.T) {
@@ -55,11 +63,19 @@ func TestSet(t *testing.T) {
 
 		key := generateRandomString(251)
 		res, err := Set(Item{Key: key, Value: "123"})
-		if err.Error() != "client error: CLIENT_ERROR bad command line format" {
-			t.Errorf("actual %v, expected %v", err.Error() , "client error: CLIENT_ERROR")
+		if res.Key == key {
+			t.Errorf("key should be converted: actual %v, expected %v", res.Key, key)
 		}
-		if res != nil {
-			t.Errorf("actual %v, expected %v", res, "nil")
+		if err != nil {
+			t.Errorf("actual %v, expected %v", err, "nil")
+		}
+
+		res, err = Get(key)
+		if res.Value != "123" {
+			t.Errorf("actual %v, expected %v", res.Value, "123")
+		}
+		if err != nil {
+			t.Errorf("actual %v, expected %v", err, "nil")
 		}
 	})
 }

--- a/client_test.go
+++ b/client_test.go
@@ -86,7 +86,7 @@ func TestMemcachedInjection(t *testing.T) {
 
 		key := "foo\r\nset bar 0 0 4\r\ntest"
 		actual, err := Get(key)
-		if actual != nil {
+		if actual.Value != "" {
 			t.Errorf("actual %v, expected %v", actual, "nil")
 		}
 		if err != nil {
@@ -106,12 +106,11 @@ func TestMemcachedInjection(t *testing.T) {
 		flushAll(t)
 
 		actual, err := Set(Item{Key:generateRandomString(251), Value: "set injected 0 3600 5\r\n12345"})
-		if actual != nil {
-			t.Errorf("actual %v, expected %v", actual, "nil")
+		if actual.Value != "set injected 0 3600 5\r\n12345" {
+			t.Errorf("actual %v, expected %v", actual, "set injected 0 3600 5\r\n12345")
 		}
-		_, isErrClient := err.(*ErrClient)
-		if !isErrClient {
-			t.Errorf("actual %v, expected %v", err, "ErrClient")
+		if err != nil {
+			t.Errorf("actual %v, expected %v", err, "nil")
 		}
 
 		actual2, _ := Get("injected")
@@ -146,11 +145,11 @@ func TestSetAndGet(t *testing.T) {
 		key = generateRandomString(251)
 		Set(Item{Key: key, Value: "123", Exptime: 0})
 		actual, err = Get(key)
-		if actual != nil {
-			t.Errorf("actual %v, expected %v", actual, "nil")
+		if actual.Value != "123" {
+			t.Errorf("actual %v, expected %v", actual, "123")
 		}
-		if err.Error() != "client error: CLIENT_ERROR" {
-			t.Errorf("actual %v, expected %v", err.Error() , "memcached returned CLIENT_ERROR: CLIENT_ERROR")
+		if err != nil {
+			t.Errorf("actual %v, expected %v", err, "nil")
 		}
 	})
 
@@ -158,8 +157,8 @@ func TestSetAndGet(t *testing.T) {
 		flushAll(t)
 		
 		actual, err := Get("hoge")
-		if actual != nil {
-			t.Errorf("actual %v, expected %v", actual, "nil")
+		if actual.Value != "" {
+			t.Errorf("actual %v, expected %v", actual, "")
 		}
 		if err != nil {
 			t.Errorf("return error %v", err)

--- a/client_test.go
+++ b/client_test.go
@@ -60,6 +60,27 @@ func TestSet(t *testing.T) {
 	})
 }
 
+func TestMemcachedInjection(t *testing.T) {
+	flushAll(t)
+
+	key := "foo\r\nset bar 0 0 4\r\ntest"
+	actual, err := Get(key)
+	if actual != nil {
+		t.Errorf("actual %v, expected %v", actual, "nil")
+	}
+	if err != nil {
+		t.Errorf("actual %v, expected %v", err, "nil")
+	}
+
+	actual2, err2 := Get("bar")
+	if actual2.Value == "test" {
+		t.Errorf("it has MemcachedInjection risk!. actual %v, expected %v", actual2, "nil")
+	}
+	if err2 != nil {
+		t.Errorf("actual %v, expected %v", err2, "nil")
+	}
+}
+
 func TestSetAndGet(t *testing.T) {
 	t.Run("Test Key size", func(t *testing.T) {
 		flushAll(t)

--- a/client_test.go
+++ b/client_test.go
@@ -73,8 +73,8 @@ func TestMemcachedInjection(t *testing.T) {
 	}
 
 	actual2, err2 := Get("bar")
-	if actual2.Value == "test" {
-		t.Errorf("it has MemcachedInjection risk!. actual %v, expected %v", actual2, "nil")
+	if actual2 == (&Response{}) {
+		t.Errorf("it has MemcachedInjection risk!. actual %v, expected %v", actual2, "Response{}")
 	}
 	if err2 != nil {
 		t.Errorf("actual %v, expected %v", err2, "nil")

--- a/client_test.go
+++ b/client_test.go
@@ -29,6 +29,8 @@ func generateRandomString(n int) string {
 
 func TestSet(t *testing.T) {
 	t.Run("when the Key size is 250", func(t *testing.T) {
+		flushAll(t)
+
 		key := generateRandomString(250)
 		res, err := Set(Item{Key: key, Value: "123"})
 		if err != nil {
@@ -49,6 +51,8 @@ func TestSet(t *testing.T) {
 	})
 
 	t.Run("when the Key size is 251", func(t *testing.T) {
+		flushAll(t)
+
 		key := generateRandomString(251)
 		res, err := Set(Item{Key: key, Value: "123"})
 		if err.Error() != "client error: CLIENT_ERROR bad command line format" {
@@ -148,6 +152,8 @@ func TestSetAndGet(t *testing.T) {
 }
 
 func TestGets(t *testing.T) {
+	flushAll(t)
+
 	// The size is 250
 	key := generateRandomString(250)
 	client := NewClient([]string{testServer}, Config{})

--- a/client_test.go
+++ b/client_test.go
@@ -118,6 +118,19 @@ func TestMemcachedInjection(t *testing.T) {
 			t.Errorf("it has MemcachedInjection risk!. actual %v, expected %v", actual2, "Response{}")
 		}
 	})
+
+	t.Run("argument injection", func(t *testing.T) {
+		flushAll(t)
+
+		Set(Item{Key:"key 0", Value: "123456789012345678901234567890\r\nset injected 0 3600 3\r\nINJ", Exptime: 30})
+		actual, err := Get("injected")
+		if actual.Value != "" {
+			t.Errorf("it has MemcachedInjection risk!. actual %v, expected %v", actual, "")
+		}
+		if err != nil {
+			t.Errorf("actual %v, expected %v", err, "nil")
+		}
+	})
 }
 
 func TestSetAndGet(t *testing.T) {

--- a/command.go
+++ b/command.go
@@ -126,7 +126,7 @@ func (c *RetrievalCommand) Perform(conn net.Conn) (res *Response, err error) {
 	heads := strings.Split(string(headBytes), " ")
 	switch heads[0] {
 	case "END":
-		return nil, nil
+		return &Response{}, nil
 	case "VALUE":
 		rawFlags, err := strconv.ParseUint(heads[2], 16, 16)
 		if err != nil {

--- a/command.go
+++ b/command.go
@@ -18,17 +18,20 @@ const (
 
 type Command interface {
 	Perform(conn net.Conn) (res *Response, err error)
-	Key() string
+	Key() Key
 }
 
 type StorageCommand struct {
-	name string
-	item Item
+	name                  string
+	key                   Key
+	value                 string
+	flags                 Flags
+	exptime               int
 	compressThresholdByte int
 }
 
 func NewStorageCommand(name string, item Item, compressThresholdByte int) Command {
-	return &StorageCommand{name: name, item: item, compressThresholdByte: compressThresholdByte}
+	return &StorageCommand{name: name, key: newKey(item.Key), value: item.Value, flags: item.Flags, exptime: item.Exptime, compressThresholdByte: compressThresholdByte}
 }
 
 func (c *StorageCommand) Perform(conn net.Conn) (res *Response, err error) {
@@ -46,7 +49,7 @@ func (c *StorageCommand) Perform(conn net.Conn) (res *Response, err error) {
 	s := scanner.Text()
 	switch s {
 	case "STORED":
-		return &Response{Key: c.item.Key, Value: c.item.Value, Flags: flags}, nil
+		return &Response{Key: c.key.body, Value: c.value, Flags: flags}, nil
 	case "NOT_STORED":
 		return nil, ErrorNotStored
 	default:
@@ -54,8 +57,8 @@ func (c *StorageCommand) Perform(conn net.Conn) (res *Response, err error) {
 	}
 }
 
-func (c *StorageCommand) Key() string {
-	return c.item.Key
+func (c *StorageCommand) Key() Key {
+	return c.key
 }
 
 func (c *StorageCommand) buildRequest() ([]byte, Flags, error) {
@@ -65,7 +68,7 @@ func (c *StorageCommand) buildRequest() ([]byte, Flags, error) {
 	}
 
 	byteSize := len(val)
-	req := []string{c.name, c.item.Key, strconv.FormatUint(uint64(flags.Value),10), strconv.Itoa(c.item.Exptime), strconv.Itoa(byteSize)}
+	req := []string{c.name, c.key.body, strconv.FormatUint(uint64(flags.Value),10), strconv.Itoa(c.exptime), strconv.Itoa(byteSize)}
 
 	r1 := append([]byte(strings.Join(req, " ")+Newline), val...)
 	r2 := append(r1, []byte(Newline)...)
@@ -73,7 +76,7 @@ func (c *StorageCommand) buildRequest() ([]byte, Flags, error) {
 }
 
 func (c *StorageCommand) serialize() ([]byte, Flags, error) {
-	val := []byte(c.item.Value)
+	val := []byte(c.value)
 
 	if !c.shouldCompress(val) {
 		return val, Flags{}, nil
@@ -88,7 +91,7 @@ func (c *StorageCommand) serialize() ([]byte, Flags, error) {
 }
 
 func (c *StorageCommand) shouldCompress(value []byte) bool {
-	if c.item.Flags.shouldCompress() {
+	if c.flags.shouldCompress() {
 		return true
 	}
 
@@ -101,11 +104,11 @@ func (c *StorageCommand) shouldCompress(value []byte) bool {
 
 type RetrievalCommand struct {
 	name string
-	key string
+	key Key
 }
 
 func NewRetrievalCommand(name string, key string) Command {
-	return &RetrievalCommand{name: name, key: key}
+	return &RetrievalCommand{name: name, key: newKey(key)}
 }
 
 func (c *RetrievalCommand) Perform(conn net.Conn) (res *Response, err error) {
@@ -162,17 +165,17 @@ func (c *RetrievalCommand) Perform(conn net.Conn) (res *Response, err error) {
 		} else {
 			val = string(buf.Bytes())
 		}
-		return &Response{Key: c.key, Value: val, Flags: flags, CasId: uint64(casId)}, nil
+		return &Response{Key: c.key.body, Value: val, Flags: flags, CasId: uint64(casId)}, nil
 	default:
 		return nil, handleErrorResponse(heads[0])
 	}
 }
 
-func (c *RetrievalCommand) Key() string {
+func (c *RetrievalCommand) Key() Key {
 	return c.key
 }
 
 func (c *RetrievalCommand) buildRequest() []byte {
-	req := []string{c.name, c.key}
+	req := []string{c.name, c.key.body}
 	return []byte(strings.Join(req, " ") + Newline)
 }

--- a/servers.go
+++ b/servers.go
@@ -20,7 +20,7 @@ func NewServers(servers []string, connectTimeout time.Duration) Servers {
 }
 
 func (s *Servers) request(command Command) (res *Response, err error) {
-	conn, err := s.connect(command.Key())
+	conn, err := s.connect(command.Key().body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://www.blackhat.com/docs/us-14/materials/us-14-Novikov-The-New-Page-Of-Injections-Book-Memcached-Injections-WP.pdf
>Memcache injections classification
5.1 Batch injection (command injection) — 0x0a/0x0d bytes
5.2 Parser state breaking (interprets data to store as command)
5.3 Argument injection — 0x20 byte
5.4 Data length breaking (null-byte)