### PR TITLE
Configure Key Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ import (
 )
 
 func main() {
-	mc := memgo.NewClient([]string{"cache1.example.com:11211", "cache2.example.com:11211"}, memgo.Config{ConnectTimeout: 100 * time.Millisecond})
+	mc := memgo.NewClient(
+          		[]string{"cache1.example.com:11211", "cache2.example.com:11211"},
+          		memgo.Config{
+          			ConnectTimeout: 100 * time.Millisecond,
+          			Namespace: "app_v1",
+          		})
 	mc.Set(mc.Item{Key: "foo", Value: "my value"})
 
 	res, err := mc.Get("foo")

--- a/client_test.go
+++ b/client_test.go
@@ -328,3 +328,41 @@ func TestCompress(t *testing.T) {
 		}
 	})
 }
+
+func TestNamespace(t *testing.T) {
+	client := NewClient([]string{testServer}, Config{Namespace: "test"})
+
+	t.Run("When the length of key is 250", func(t *testing.T) {
+		flushAll(t)
+
+		key := generateRandomString(245) // len("test" + key) is 250
+		client.Set(Item{Key: key, Value: "123"})
+		actual, err := client.Get(key)
+		if actual.Value != "123" {
+			t.Errorf("actual %v, expected %v", actual, "123")
+		}
+		if actual.Key != "test:"+key {
+			t.Errorf("actual %v, expected %v", actual.Key, "test:"+key)
+		}
+		if err != nil {
+			t.Errorf("return error %v", err)
+		}
+	})
+
+	t.Run("When the length of key is 251", func(t *testing.T) {
+		flushAll(t)
+
+		key := generateRandomString(246) // len("test" + key) is 251
+		client.Set(Item{Key: key, Value: "123"})
+		actual, err := client.Get(key)
+		if actual.Value != "123" {
+			t.Errorf("actual %v, expected %v", actual, "123")
+		}
+		if actual.Key == "test:"+key {
+			t.Errorf("actual %v, expected %v", actual.Key, "test:"+key)
+		}
+		if err != nil {
+			t.Errorf("actual %v, expected %v", err, "nil")
+		}
+	})
+}

--- a/command.go
+++ b/command.go
@@ -30,8 +30,8 @@ type StorageCommand struct {
 	compressThresholdByte int
 }
 
-func NewStorageCommand(name string, item Item, compressThresholdByte int) Command {
-	return &StorageCommand{name: name, key: newKey(item.Key), value: item.Value, flags: item.Flags, exptime: item.Exptime, compressThresholdByte: compressThresholdByte}
+func NewStorageCommand(name string, item Item, key Key, compressThresholdByte int) Command {
+	return &StorageCommand{name: name, key: key, value: item.Value, flags: item.Flags, exptime: item.Exptime, compressThresholdByte: compressThresholdByte}
 }
 
 func (c *StorageCommand) Perform(conn net.Conn) (res *Response, err error) {
@@ -107,8 +107,8 @@ type RetrievalCommand struct {
 	key Key
 }
 
-func NewRetrievalCommand(name string, key string) Command {
-	return &RetrievalCommand{name: name, key: newKey(key)}
+func NewRetrievalCommand(name string, key Key) Command {
+	return &RetrievalCommand{name: name, key: key}
 }
 
 func (c *RetrievalCommand) Perform(conn net.Conn) (res *Response, err error) {

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	// You can't use 0. If 0, 1 second is used.
 	ConnectTimeout time.Duration
 	CompressThresholdByte int
+	Namespace string
 }
 
 func (config *Config) connectTimeout() time.Duration {


### PR DESCRIPTION
If specified, prepends each key with the namespace.

### Example:
```
client := NewClient([]string{testServer}, Config{Namespace: "app_v1"})
client.Set(Item{Key: "key", Value: "123"})
```
It prepends `app_v1` to the key, so that `app_v1:key` is used in memgo actually.